### PR TITLE
Fix simultaneous start of timestamp

### DIFF
--- a/src/test/java/com/farao_community/farao/core_cc/adapter/service/JobLauncherManualServiceTest.java
+++ b/src/test/java/com/farao_community/farao/core_cc/adapter/service/JobLauncherManualServiceTest.java
@@ -25,15 +25,9 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.function.Supplier;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Vincent Bochet {@literal <vincent.bochet at rte-france.com>}

--- a/src/test/java/com/farao_community/farao/core_cc/adapter/service/JobLauncherManualServiceTest.java
+++ b/src/test/java/com/farao_community/farao/core_cc/adapter/service/JobLauncherManualServiceTest.java
@@ -57,7 +57,7 @@ class JobLauncherManualServiceTest {
 
     @Test
     @DisplayName("Testing that a timestamp cannot be launched twice simultaneously.")
-    void testSimultaneity(){
+    void testSimultaneity() {
         final String timestamp = "2024-09-18T09:30Z";
         final TaskDto taskDto = new TaskDto(UUID.randomUUID(), OffsetDateTime.parse(timestamp), TaskStatus.ERROR, null, null, null, null, null, null);
         Mockito.when(taskManagerService.getTaskFromTimestamp(timestamp)).thenReturn(Optional.of(taskDto));

--- a/src/test/java/com/farao_community/farao/core_cc/adapter/service/JobLauncherManualServiceTest.java
+++ b/src/test/java/com/farao_community/farao/core_cc/adapter/service/JobLauncherManualServiceTest.java
@@ -10,6 +10,7 @@ import com.farao_community.farao.gridcapa.task_manager.api.TaskDto;
 import com.farao_community.farao.gridcapa.task_manager.api.TaskParameterDto;
 import com.farao_community.farao.gridcapa.task_manager.api.TaskStatus;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -24,6 +25,15 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Vincent Bochet {@literal <vincent.bochet at rte-france.com>}
@@ -49,6 +59,65 @@ class JobLauncherManualServiceTest {
         service.launchJob(timestamp, List.of());
 
         Mockito.verifyNoInteractions(adapterService);
+    }
+
+    @Test
+    @DisplayName("Testing that a timestamp cannot be launched twice simultaneously.")
+    void testSimultaneity(){
+        final String timestamp = "2024-09-18T09:30Z";
+        final TaskDto taskDto = new TaskDto(UUID.randomUUID(), OffsetDateTime.parse(timestamp), TaskStatus.ERROR, null, null, null, null, null, null);
+        Mockito.when(taskManagerService.getTaskFromTimestamp(timestamp)).thenReturn(Optional.of(taskDto));
+        // Use CountDownLatch to ensure both threads start simultaneously
+        final CountDownLatch startLatch = new CountDownLatch(1);
+        final Runnable runnable = () -> {
+            try {
+                startLatch.await(); // Both threads wait here
+                service.launchJob(timestamp, List.of());
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        };
+        final Thread t1 = new Thread(runnable);
+        final Thread t2 = new Thread(runnable);
+        t1.start();
+        t2.start();
+        // Release both threads at once
+        startLatch.countDown();
+        // One thread must have been stopped
+        Mockito.verify(taskManagerService, Mockito.times(1)).getTaskFromTimestamp(Mockito.anyString());
+    }
+
+    @Test
+    @DisplayName("Test that a timestamp can be relaunched once it has completed")
+    void testRestartOk() throws InterruptedException {
+        final String timestamp = "2024-09-18T09:30Z";
+        final TaskDto taskDto = new TaskDto(UUID.randomUUID(), OffsetDateTime.parse(timestamp), TaskStatus.SUCCESS, null, null, null, null, null, null);
+        Mockito.when(taskManagerService.getTaskFromTimestamp(timestamp)).thenReturn(Optional.of(taskDto));
+        final Runnable runnable = () -> service.launchJob(timestamp, List.of());
+        final Thread t1 = new Thread(runnable);
+        t1.start();
+        t1.join();
+        // Wait for first thread to end
+        final Thread t2 = new Thread(runnable);
+        t2.start();
+        t2.join();
+        // Verify the timestamp can be relaunched
+        Mockito.verify(taskManagerService, Mockito.times(2)).getTaskFromTimestamp(Mockito.anyString());
+    }
+
+    @Test
+    @DisplayName("Testing that a timestamp is properly cleaned up after an exception occurs.")
+    void testException() {
+        final String timestamp = "2024-09-18T09:30Z";
+        final TaskDto taskDto = new TaskDto(UUID.randomUUID(), OffsetDateTime.parse(timestamp), TaskStatus.READY, null, null, null, null, null, null);
+        Mockito.when(taskManagerService.getTaskFromTimestamp(timestamp))
+                // crashes on first run
+                .thenThrow(new RuntimeException())
+                // then succeeds on second
+                .thenReturn(Optional.of(taskDto));
+        assertThrows(RuntimeException.class, () -> service.launchJob(timestamp, List.of()));
+        service.launchJob(timestamp, List.of());
+        Mockito.verify(taskManagerService, Mockito.times(2)).getTaskFromTimestamp(Mockito.anyString());
     }
 
     @ParameterizedTest

--- a/src/test/java/com/farao_community/farao/core_cc/adapter/service/JobLauncherManualServiceTest.java
+++ b/src/test/java/com/farao_community/farao/core_cc/adapter/service/JobLauncherManualServiceTest.java
@@ -37,7 +37,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @ExtendWith(MockitoExtension.class)
 class JobLauncherManualServiceTest {
 
-
     @Mock
     private CoreCCAdapterService adapterService;
     @Mock


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*



**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced job launching logic to prevent duplicate and simultaneous executions.
  - Improved error handling and logging for clearer job execution status.

- **Tests**
  - Added comprehensive tests to validate concurrent job handling, proper restart after successful completion, and robust cleanup in case of exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->